### PR TITLE
update badge link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Runs a single command using the runners shell
       - name: Build docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile
           push: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rviz_rotatable_image_plugin
 
-[![](https://github.com/LKSeng/rviz_rotatable_image_plugin/workflows/noetic_build/badge.svg?branch=main)](https://github.com/LKSeng/rviz_rotatable_image_plugin/actions)
+[![](https://github.com/LKSeng/rviz_rotatable_image_plugin/workflows/noetic_build/badge.svg)](https://github.com/LKSeng/rviz_rotatable_image_plugin/actions)
 
 RViz plugin to rotate `sensor_msgs::Image` for visualisation purposes in-situ, especially so if camera is mounted at an angle. For avoidance of doubt, note that this plugin does not publish the rotated image.
 


### PR DESCRIPTION
Update the github actions badge status link. Apparently from [troubleshooting workflow status badge](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) it is possible that there is no support for specific branch query when using the (undocumented?) version of showing branch by workflow name (as compared to workflow file name).